### PR TITLE
fix: bootBuildImage 명령어 보완

### DIFF
--- a/integration-service/build.gradle
+++ b/integration-service/build.gradle
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.java.dev.jna:jna-platform:5.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'io.projectreactor:reactor-tools'
     compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
- 기본 JRE로 실행
- JDK가 필요하기 때문에 에러가 발생하여 jna-platform모듈 추가